### PR TITLE
trim absolute path in bamboo-core.a

### DIFF
--- a/bamboo/CMakeLists.txt
+++ b/bamboo/CMakeLists.txt
@@ -8,6 +8,7 @@ add_custom_command(OUTPUT bamboo-core.a bamboo-core.h
     DEPENDS ${BAMBOO_GO_SRCS} ${BAMBOO_CORE_GO_SRCS} go.mod
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMAND env go build -buildmode=c-archive
+                -trimpath
                 -o "${CMAKE_CURRENT_BINARY_DIR}/bamboo-core.a"
             ${BAMBOO_GO_SRCS})
 add_custom_target(bamboo-core DEPENDS bamboo-core.a)


### PR DESCRIPTION
test: After `strip -x libbamboo.so`, do `grep /path/to/repo libbamboo.so`.
main: still shows match.
pr: no match.