### PR TITLE
Add missing label for `bamboo.conf`

### DIFF
--- a/src/bamboo.conf.in
+++ b/src/bamboo.conf.in
@@ -1,6 +1,7 @@
 [InputMethod]
 Name=Bamboo
 Icon=fcitx_bamboo
+Label=VN
 LangCode=vi
 Addon=bamboo
 Configurable=True


### PR DESCRIPTION
Currently fcitx5 tray icon does not display anything when the active IME is Bamboo.