### PR TITLE
fix: punctuation keys don't commit preedit text when enabling macro

### DIFF
--- a/bamboo/fcitxbambooengine.go
+++ b/bamboo/fcitxbambooengine.go
@@ -253,10 +253,10 @@ func (e *FcitxBambooEngine) getCommitText(keyVal, state uint32) (string, bool) {
 			var keyS = string(keyRune)
 			if keyVal == FcitxSpace && e.macroTable.HasKey(oldText) {
 				e.preeditor.Reset()
-				return e.expandMacro(oldText) + keyS, keyVal == FcitxSpace
+				return e.expandMacro(oldText) + keyS, true
 			} else {
 				e.preeditor.ProcessKey(keyRune, e.getBambooInputMode())
-				return oldText + keyS, keyVal == FcitxSpace
+				return oldText + keyS, true
 			}
 		}
 		if bamboo.HasAnyVietnameseRune(oldText) && e.mustFallbackToEnglish() {


### PR DESCRIPTION
Problem:
When enabling macro, if I type a punctuation like `:`, the "preedit" state is still on because the function `getCommitText()` returns `keyVal == FcitxSpace`, which also means the only key that can commit text is `<Space>` instead of all word-break-characters defined by [bamboo](https://github.com/BambooEngine/bamboo-core)

Solution:
Should returns `true` instead

Closes #14