### PR TITLE
fix: disable macro by default

### DIFF
--- a/src/bambooconfig.h
+++ b/src/bambooconfig.h
@@ -115,7 +115,7 @@ FCITX_CONFIGURATION(
     OptionWithAnnotation<std::string, StringListAnnotation> outputCharset{
         this, "OutputCharset", _("Output Charset"), "Unicode"};
     Option<bool> spellCheck{this, "SpellCheck", _("Enable spell check"), true};
-    Option<bool> macro{this, "Macro", _("Enable Macro"), true};
+    Option<bool> macro{this, "Macro", _("Enable Macro"), false};
     Option<bool> capitalizeMacro{this, "CapitalizeMacro", _("Capitalize Macro"),
                                  true};
     Option<bool> autoNonVnRestore{this, "AutoNonVnRestore",


### PR DESCRIPTION
Problem:
- When macro is enabled, the only character that can commit text is `<Space>` (instead of space + punctuations like dot, colons, etc), which is **_bad UX_**, because when writing code in VSCode or Neovim, I would never get autocompletion.
- Macro feature requires users to define macro via fcitx5-config UI. When users just install fcitx5-bamboo, they don't have any macros yet, so enabling macro not only doesn't give users any benefits, but also makes UX worse (as I said above)

Solution:
- Disable macro by default